### PR TITLE
Replace all "\r\n" when parsing data

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -310,7 +310,7 @@ function StreamReader(read) {
 	function parse(data, initExpected) {
 		var lines, i, last;
 		data = tail + data;
-		data = data.replace(/\r*\n+/, "\n");
+		data = data.replace(/\r*\n+/g, "\n");
 		lines = data.split("\n");
 		last = lines.length - 1;
 		for (i = 0; i < last; i++) {


### PR DESCRIPTION
Replace **ALL** "\r\n" with "\n"